### PR TITLE
Match Responses to what Electron autoUpdater expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Carrots
 
+> 🪳 Not ready yet, working on bugs.
+
 TypeScript-based Electron downloads and updates server that uses GitHub to serve files.
 
 ## Setup

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,6 +43,7 @@ enum Platform {
   WIN32_ARM64 = "win32-arm64",
   WIN32_IA32 = "win32-ia32",
   WIN32_X64 = "win32-x64",
+  NUPKG = "nupkg",
   SNAP_ARM64 = "snap-arm64",
   SNAP_X64 = "snap-x64",
 }
@@ -124,6 +125,10 @@ const filenameToPlatform = (fileName: string): Platform | null => {
 
   if (lowerFileName.includes("win32-arm64")) {
     return Platform.WIN32_ARM64;
+  }
+
+  if (lowerFileName.endsWith(".nupkg")) {
+    return Platform.NUPKG;
   }
 
   if (lowerFileName.endsWith(".deb") || lowerFileName.endsWith(".rpm")) {
@@ -368,6 +373,15 @@ async function carrots(config: Config) {
       return;
     }
 
+    // Address
+    const address = `${
+      req.headers.protocol ||
+      req.headers.host?.includes("localhost") ||
+      req.headers.host?.includes("[::]")
+        ? "http"
+        : "https"
+    }://${req.headers.host || ""}`;
+
     // Parse platform
     if (!params.platform) {
       res.statusCode = 400;
@@ -421,27 +435,32 @@ async function carrots(config: Config) {
         return;
       }
 
+      const patchedReleases = asset.RELEASES.replace(
+        /([A-Fa-f0-9]+)\s([^\s]+\.nupkg)\s(\d+)/g,
+        `$1 ${address}/download/nupkg $3`
+      );
+
       res.statusCode = 200;
       res.setHeader(
         "content-length",
-        Buffer.byteLength(asset.RELEASES, "utf8")
+        Buffer.byteLength(patchedReleases, "utf8")
       );
       res.setHeader("content-type", "application/octet-stream");
-      res.end(asset.RELEASES);
+      res.end(patchedReleases);
       return;
     }
 
     // Proxy the update
-    const assetRes = await fetch(asset.api_url, {
-      headers: {
-        Accept: "application/octet-stream",
-        ...(config.token ? { Authorization: `Bearer ${config.token}` } : {}),
-      },
-      redirect: "manual",
-    });
-    res.statusCode = 302;
-    res.setHeader("Location", assetRes.headers.get("Location") || "");
-    res.end();
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(
+      JSON.stringify({
+        url: `${address}/download/${params.platform}?update=true`,
+        name: asset.version,
+        notes: asset.notes,
+        pub_date: asset.date,
+      })
+    );
     return;
   });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -75,6 +75,7 @@ function requestToPlatform(platformRaw: string): Platform | null {
   if (platform === "snap-arm64") return Platform.SNAP_ARM64;
   if (platform === "snap") return Platform.SNAP_X64;
   if (platform === "linux") return Platform.SNAP_X64;
+  if (platform === "nupkg") return Platform.NUPKG;
   return null;
 }
 
@@ -320,7 +321,7 @@ async function carrots(config: Config) {
   });
 
   // Redirect to download latest release
-  router.get("/download/:platform", async (req, res, params) => {
+  router.get("/download/:platform/:file?", async (req, res, params) => {
     const { latest, platforms, version, date } = await updateCache(res);
     if (!latest) {
       res.statusCode = 500;
@@ -380,7 +381,7 @@ async function carrots(config: Config) {
       req.headers.host?.includes("[::]")
         ? "http"
         : "https"
-    }://${req.headers.host || ""}`;
+    }://${req.headers.host || ""}/`;
 
     // Parse platform
     if (!params.platform) {
@@ -437,7 +438,7 @@ async function carrots(config: Config) {
 
       const patchedReleases = asset.RELEASES.replace(
         /([A-Fa-f0-9]+)\s([^\s]+\.nupkg)\s(\d+)/g,
-        `$1 ${address}/download/nupkg $3`
+        `$1 ${address}download/nupkg/$2 $3`
       );
 
       res.statusCode = 200;
@@ -455,7 +456,7 @@ async function carrots(config: Config) {
     res.setHeader("Content-Type", "application/json; charset=utf-8");
     res.end(
       JSON.stringify({
-        url: `${address}/download/${params.platform}?update=true`,
+        url: `${address}download/${params.platform}`,
         name: asset.version,
         notes: asset.notes,
         pub_date: asset.date,

--- a/lib/private.test.ts
+++ b/lib/private.test.ts
@@ -141,13 +141,17 @@ describe("update", () => {
   it("should give update for an old version of mac arm", async () => {
     const res = await fetch(`${address}update/darwin_arm64/0.57.0`);
     expect(res.status).toEqual(200);
-    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
   });
 
   it("should give update for an old version mac x64", async () => {
     const res = await fetch(`${address}update/darwin/0.57.0`);
     expect(res.status).toEqual(200);
-    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
   });
 });
 
@@ -156,14 +160,18 @@ describe("latest", () => {
     const res = await fetch(
       `${address}update/win32/${currentVersion}/RELEASES`
     );
-    expect(res.status).toEqual(204);
+    expect(res.status).toEqual(200);
+    const text = await res.text();
+    expect(text).toContain(".nupkg");
   });
 
   it("should not give update for up-to-date windows x64", async () => {
     const res = await fetch(
       `${address}update/win32/${currentVersion}/releases`
     );
-    expect(res.status).toEqual(204);
+    expect(res.status).toEqual(200);
+    const text = await res.text();
+    expect(text).toContain(".nupkg");
   });
 
   it("should not give update for up-to-date mac arm", async () => {

--- a/lib/private.test.ts
+++ b/lib/private.test.ts
@@ -122,20 +122,29 @@ describe("download", () => {
 });
 
 describe("update", () => {
-  it("should give update for an old version of windows x64", async () => {
+  it("should give nupkg info for an old version of windows x64", async () => {
     const res = await fetch(`${address}update/win32/0.57.0/RELEASES`);
     expect(res.status).toEqual(200);
     const text = await res.text();
-    expect(text).toContain(".nupkg");
-    expect(text).toContain(currentVersion);
+    expect(text).toContain(` ${address}download/nupkg `);
   });
 
   it("should give update for an old version of windows x64", async () => {
-    const res = await fetch(`${address}update/win32/0.57.0/releases`);
+    const res = await fetch(`${address}update/win32/0.57.0`);
     expect(res.status).toEqual(200);
-    const text = await res.text();
-    expect(text).toContain(".nupkg");
-    expect(text).toContain(currentVersion);
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+    const data = await res.json();
+    expect(data.url).toBe(`${address}download/win32?update=true`);
+  });
+
+  it("should give update download for an old version of windows x64", async () => {
+    const res = await fetch(`${address}download/win32?update=true`);
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename=horse-${currentVersion}-win32-x64-setup.exe`
+    );
   });
 
   it("should give update for an old version of mac arm", async () => {
@@ -143,6 +152,16 @@ describe("update", () => {
     expect(res.status).toEqual(200);
     expect(res.headers.get("content-type")).toBe(
       "application/json; charset=utf-8"
+    );
+    const data = await res.json();
+    expect(data.url).toBe(`${address}download/darwin_arm64?update=true`);
+  });
+
+  it("should give update for an old version of mac arm", async () => {
+    const res = await fetch(`${address}download/darwin_arm64?update=true`);
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename=Horse-darwin-arm64-${currentVersion}.zip`
     );
   });
 
@@ -152,6 +171,16 @@ describe("update", () => {
     expect(res.headers.get("content-type")).toBe(
       "application/json; charset=utf-8"
     );
+    const data = await res.json();
+    expect(data.url).toBe(`${address}download/darwin?update=true`);
+  });
+
+  it("should give update for an old version mac x64", async () => {
+    const res = await fetch(`${address}download/darwin?update=true`);
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename=Horse-darwin-x64-${currentVersion}.zip`
+    );
   });
 });
 
@@ -160,18 +189,14 @@ describe("latest", () => {
     const res = await fetch(
       `${address}update/win32/${currentVersion}/RELEASES`
     );
-    expect(res.status).toEqual(200);
-    const text = await res.text();
-    expect(text).toContain(".nupkg");
+    expect(res.status).toEqual(204);
   });
 
   it("should not give update for up-to-date windows x64", async () => {
     const res = await fetch(
       `${address}update/win32/${currentVersion}/releases`
     );
-    expect(res.status).toEqual(200);
-    const text = await res.text();
-    expect(text).toContain(".nupkg");
+    expect(res.status).toEqual(204);
   });
 
   it("should not give update for up-to-date mac arm", async () => {

--- a/lib/private.test.ts
+++ b/lib/private.test.ts
@@ -126,7 +126,19 @@ describe("update", () => {
     const res = await fetch(`${address}update/win32/0.57.0/RELEASES`);
     expect(res.status).toEqual(200);
     const text = await res.text();
-    expect(text).toContain(` ${address}download/nupkg `);
+    expect(text).toContain(
+      ` ${address}download/nupkg/horse-${currentVersion}-full.nupkg `
+    );
+  });
+
+  it("should give update download for an old version of windows x64", async () => {
+    const res = await fetch(
+      `${address}download/nupkg/horse-${currentVersion}-full.nupkg`
+    );
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename=horse-${currentVersion}-full.nupkg`
+    );
   });
 
   it("should give update for an old version of windows x64", async () => {
@@ -136,15 +148,7 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data.url).toBe(`${address}download/win32?update=true`);
-  });
-
-  it("should give update download for an old version of windows x64", async () => {
-    const res = await fetch(`${address}download/win32?update=true`);
-    expect(res.status).toEqual(200);
-    expect(res.headers.get("content-disposition")).toBe(
-      `attachment; filename=horse-${currentVersion}-win32-x64-setup.exe`
-    );
+    expect(data.url).toBe(`${address}download/win32`);
   });
 
   it("should give update for an old version of mac arm", async () => {
@@ -154,11 +158,11 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data.url).toBe(`${address}download/darwin_arm64?update=true`);
+    expect(data.url).toBe(`${address}download/darwin_arm64`);
   });
 
   it("should give update for an old version of mac arm", async () => {
-    const res = await fetch(`${address}download/darwin_arm64?update=true`);
+    const res = await fetch(`${address}download/darwin_arm64`);
     expect(res.status).toEqual(200);
     expect(res.headers.get("content-disposition")).toBe(
       `attachment; filename=Horse-darwin-arm64-${currentVersion}.zip`
@@ -172,11 +176,11 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data.url).toBe(`${address}download/darwin?update=true`);
+    expect(data.url).toBe(`${address}download/darwin`);
   });
 
   it("should give update for an old version mac x64", async () => {
-    const res = await fetch(`${address}download/darwin?update=true`);
+    const res = await fetch(`${address}download/darwin`);
     expect(res.status).toEqual(200);
     expect(res.headers.get("content-disposition")).toBe(
       `attachment; filename=Horse-darwin-x64-${currentVersion}.zip`

--- a/lib/public.test.ts
+++ b/lib/public.test.ts
@@ -133,26 +133,46 @@ describe("download", () => {
     );
   });
 
-  it("should give download for snap", async () => {
-    const res = await fetch(`${address}download/snap`);
-    expect(res.status).toEqual(200);
-    expect(res.headers.get("content-disposition")).toBe(
-      `attachment; filename=hyper_${currentVersion}_amd64.snap`
-    );
-  });
+  // it("should give download for snap", async () => {
+  //   const res = await fetch(`${address}download/snap`);
+  //   expect(res.status).toEqual(200);
+  //   expect(res.headers.get("content-disposition")).toBe(
+  //     `attachment; filename=hyper_${currentVersion}_amd64.snap`
+  //   );
+  // });
 });
 
 describe("update", () => {
   it("should give update for an old version of mac arm", async () => {
     const res = await fetch(`${address}update/darwin_arm64/0.57.0`);
     expect(res.status).toEqual(200);
-    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+    const data = await res.json();
+    expect(data).toEqual({
+      name: "v3.4.1",
+      notes:
+        "V3.4.1\r\n\r\nBased on some reports of errors with `node-pty`, reverting it to a stable version.\r\n\r\n|   OS    | Installer |                                                                                                 |                                                                                                  |\r\n| :-----: | :-------: | :---------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |\r\n|   Mac   |    dmg    | [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-x64.dmg) (Intel) | [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-arm64.dmg) (M1) |\r\n|  Linux  |    deb    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.deb)      |     [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_arm64.deb)      |\r\n|         |    rpm    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.x86_64.rpm)      |    [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.aarch64.rpm)     |\r\n|         | AppImage  |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1.AppImage)       |   [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-arm64.AppImage)   |\r\n|         |   snap    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.snap)      |                                                                                                  |\r\n| Windows |    exe    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-Setup-3.4.1.exe)      |                                                                                                  |\r\n\r\n\r\n## What's Changed\r\n* Use stable node-pty in https://github.com/vercel/hyper/pull/6964\r\n\r\n\r\n**Full Changelog**: https://github.com/vercel/hyper/compare/v3.4.0...v3.4.1",
+      pub_date: "2023-01-08T00:56:10Z",
+      url: "http://localhost:3000/download/darwin_arm64?update=true",
+    });
   });
 
   it("should give update for an old version mac x64", async () => {
     const res = await fetch(`${address}update/darwin/0.57.0`);
     expect(res.status).toEqual(200);
-    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(res.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8"
+    );
+    const data = await res.json();
+    expect(data).toEqual({
+      name: "v3.4.1",
+      notes:
+        "V3.4.1\r\n\r\nBased on some reports of errors with `node-pty`, reverting it to a stable version.\r\n\r\n|   OS    | Installer |                                                                                                 |                                                                                                  |\r\n| :-----: | :-------: | :---------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |\r\n|   Mac   |    dmg    | [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-x64.dmg) (Intel) | [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-arm64.dmg) (M1) |\r\n|  Linux  |    deb    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.deb)      |     [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_arm64.deb)      |\r\n|         |    rpm    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.x86_64.rpm)      |    [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.aarch64.rpm)     |\r\n|         | AppImage  |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1.AppImage)       |   [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-arm64.AppImage)   |\r\n|         |   snap    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.snap)      |                                                                                                  |\r\n| Windows |    exe    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-Setup-3.4.1.exe)      |                                                                                                  |\r\n\r\n\r\n## What's Changed\r\n* Use stable node-pty in https://github.com/vercel/hyper/pull/6964\r\n\r\n\r\n**Full Changelog**: https://github.com/vercel/hyper/compare/v3.4.0...v3.4.1",
+      pub_date: "2023-01-08T00:56:10Z",
+      url: "http://localhost:3000/download/darwin?update=true",
+    });
   });
 });
 

--- a/lib/public.test.ts
+++ b/lib/public.test.ts
@@ -150,7 +150,7 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data.url).toBe(`${address}download/darwin_arm64?update=true`);
+    expect(data.url).toBe(`${address}download/darwin_arm64`);
   });
 
   it("should give update for an old version mac x64", async () => {
@@ -160,7 +160,7 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data.url).toBe(`${address}download/darwin?update=true`);
+    expect(data.url).toBe(`${address}download/darwin`);
   });
 });
 

--- a/lib/public.test.ts
+++ b/lib/public.test.ts
@@ -133,13 +133,13 @@ describe("download", () => {
     );
   });
 
-  // it("should give download for snap", async () => {
-  //   const res = await fetch(`${address}download/snap`);
-  //   expect(res.status).toEqual(200);
-  //   expect(res.headers.get("content-disposition")).toBe(
-  //     `attachment; filename=hyper_${currentVersion}_amd64.snap`
-  //   );
-  // });
+  it("should give download for snap", async () => {
+    const res = await fetch(`${address}download/snap`);
+    expect(res.status).toEqual(200);
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename=hyper_${currentVersion}_amd64.snap`
+    );
+  });
 });
 
 describe("update", () => {
@@ -150,13 +150,7 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data).toEqual({
-      name: "v3.4.1",
-      notes:
-        "V3.4.1\r\n\r\nBased on some reports of errors with `node-pty`, reverting it to a stable version.\r\n\r\n|   OS    | Installer |                                                                                                 |                                                                                                  |\r\n| :-----: | :-------: | :---------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |\r\n|   Mac   |    dmg    | [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-x64.dmg) (Intel) | [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-arm64.dmg) (M1) |\r\n|  Linux  |    deb    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.deb)      |     [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_arm64.deb)      |\r\n|         |    rpm    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.x86_64.rpm)      |    [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.aarch64.rpm)     |\r\n|         | AppImage  |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1.AppImage)       |   [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-arm64.AppImage)   |\r\n|         |   snap    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.snap)      |                                                                                                  |\r\n| Windows |    exe    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-Setup-3.4.1.exe)      |                                                                                                  |\r\n\r\n\r\n## What's Changed\r\n* Use stable node-pty in https://github.com/vercel/hyper/pull/6964\r\n\r\n\r\n**Full Changelog**: https://github.com/vercel/hyper/compare/v3.4.0...v3.4.1",
-      pub_date: "2023-01-08T00:56:10Z",
-      url: "http://localhost:3000/download/darwin_arm64?update=true",
-    });
+    expect(data.url).toBe(`${address}download/darwin_arm64?update=true`);
   });
 
   it("should give update for an old version mac x64", async () => {
@@ -166,13 +160,7 @@ describe("update", () => {
       "application/json; charset=utf-8"
     );
     const data = await res.json();
-    expect(data).toEqual({
-      name: "v3.4.1",
-      notes:
-        "V3.4.1\r\n\r\nBased on some reports of errors with `node-pty`, reverting it to a stable version.\r\n\r\n|   OS    | Installer |                                                                                                 |                                                                                                  |\r\n| :-----: | :-------: | :---------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------: |\r\n|   Mac   |    dmg    | [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-x64.dmg) (Intel) | [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-mac-arm64.dmg) (M1) |\r\n|  Linux  |    deb    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.deb)      |     [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_arm64.deb)      |\r\n|         |    rpm    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.x86_64.rpm)      |    [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper-3.4.1.aarch64.rpm)     |\r\n|         | AppImage  |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1.AppImage)       |   [arm64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-3.4.1-arm64.AppImage)   |\r\n|         |   snap    |     [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/hyper_3.4.1_amd64.snap)      |                                                                                                  |\r\n| Windows |    exe    |      [x64](https://github.com/vercel/hyper/releases/download/v3.4.1/Hyper-Setup-3.4.1.exe)      |                                                                                                  |\r\n\r\n\r\n## What's Changed\r\n* Use stable node-pty in https://github.com/vercel/hyper/pull/6964\r\n\r\n\r\n**Full Changelog**: https://github.com/vercel/hyper/compare/v3.4.0...v3.4.1",
-      pub_date: "2023-01-08T00:56:10Z",
-      url: "http://localhost:3000/download/darwin?update=true",
-    });
+    expect(data.url).toBe(`${address}download/darwin?update=true`);
   });
 });
 
@@ -182,7 +170,7 @@ describe("latest", () => {
     expect(res.status).toEqual(204);
   });
 
-  it("should give update for up-to-date mac x64", async () => {
+  it("should not give update for up-to-date mac x64", async () => {
     const res = await fetch(`${address}update/darwin/${currentVersion}`);
     expect(res.status).toEqual(204);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carrots",
-  "version": "6.0.0",
+  "version": "0.0.0",
   "description": "Lightweight update server for Electron apps",
   "repository": "PascalPixel/carrots",
   "license": "MIT",


### PR DESCRIPTION
HELP WANTED: The Jest tests for updates need to be exactly what Electron.autoUpdater expects on Mac and Windows feel free to open a PR — then the actual code can be adjusted to match after.